### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.rst
+++ b/README.rst
@@ -81,3 +81,4 @@ useful information.
 .. |logo| image:: logo.svg
     :width: 24pt
     :height: 24pt
+[![Run on Repl.it](https://repl.it/badge/github/sanatmorgh/Telethon)](https://repl.it/github/sanatmorgh/Telethon)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).